### PR TITLE
[DEP-249] remove 'get help with this page' link

### DIFF
--- a/app/views/GovukWrapper.scala.html
+++ b/app/views/GovukWrapper.scala.html
@@ -98,7 +98,6 @@
         mainDataAttributes = mainDataAttributes,
         mainContentHeader = mainContentHeader,
         serviceInfo = serviceInfoBlock,
-        getHelpForm = getHelpForm,
         sidebar = sidebar)
 }
 


### PR DESCRIPTION
Link no longer required for now. Removed from gov uk wrapper template.