### PR TITLE
DEP-248

### DIFF
--- a/app/assets/javascripts/addToDataLayer.js
+++ b/app/assets/javascripts/addToDataLayer.js
@@ -10,7 +10,7 @@ export function addToDataLayer (status, el, w, d) {
       localObj = Object.assign(localObj, parser.parseData(elToAdd.getAttribute('data-gtag')))
     });
   
-    w.dataLayer.push(localObj);
+    saveToDataLayer(w,localObj);
   }
 
 
@@ -22,4 +22,9 @@ export function addToDataLayer (status, el, w, d) {
       'Session ID': new Date().getTime() + '.' + Math.random().toString(36).substring(5),
       'Hit TimeStamp': new Date().toUTCString()
     };
+  }
+
+  export function saveToDataLayer(w,itemToSave) {
+    w.dataLayer = w.dataLayer || [];
+    w.dataLayer.push(itemToSave);
   }

--- a/app/assets/javascripts/addToDataLayer.js
+++ b/app/assets/javascripts/addToDataLayer.js
@@ -3,14 +3,13 @@ import * as parser from './parseData'
 export function addToDataLayer (status, el, w, d) {
     w.dataLayer = w.dataLayer || [];
     var localData = d.querySelectorAll('[data-gtag]');
-  
-    var localObj = createDataLayerElement(status,el);
+    var dataLayerElement = createDataLayerElement(status,el);
   
     Array.prototype.forEach.call(localData, function (elToAdd, i) {
-      localObj = Object.assign(localObj, parser.parseData(elToAdd.getAttribute('data-gtag')))
+      dataLayerElement = Object.assign(dataLayerElement, parser.parseData(elToAdd.getAttribute('data-gtag')))
     });
   
-    reportEvent(w,localObj);
+    reportEvent(w,dataLayerElement);
   }
 
 

--- a/app/assets/javascripts/addToDataLayer.js
+++ b/app/assets/javascripts/addToDataLayer.js
@@ -10,7 +10,7 @@ export function addToDataLayer (status, el, w, d) {
       localObj = Object.assign(localObj, parser.parseData(elToAdd.getAttribute('data-gtag')))
     });
   
-    saveToDataLayer(w,localObj);
+    reportEvent(w,localObj);
   }
 
 
@@ -24,7 +24,7 @@ export function addToDataLayer (status, el, w, d) {
     };
   }
 
-  export function saveToDataLayer(w,itemToSave) {
+  export function reportEvent(w,itemToSave) {
     w.dataLayer = w.dataLayer || [];
     w.dataLayer.push(itemToSave);
   }

--- a/app/assets/javascripts/addToDataLayer.js
+++ b/app/assets/javascripts/addToDataLayer.js
@@ -4,17 +4,22 @@ export function addToDataLayer (status, el, w, d) {
     w.dataLayer = w.dataLayer || [];
     var localData = d.querySelectorAll('[data-gtag]');
   
-    var localObj = {
-      'event': 'DOMContentLoaded',
-      'Status': status,
-      'ID' : el,
-      'Session ID': new Date().getTime() + '.' + Math.random().toString(36).substring(5),
-      'Hit TimeStamp': new Date().toUTCString()
-    };
+    var localObj = createDataLayerElement(status,el);
   
     Array.prototype.forEach.call(localData, function (elToAdd, i) {
       localObj = Object.assign(localObj, parser.parseData(elToAdd.getAttribute('data-gtag')))
     });
   
     w.dataLayer.push(localObj);
+  }
+
+
+  export function createDataLayerElement(status,el) {
+    return {
+      'event': 'DOMContentLoaded',
+      'Status': status,
+      'ID' : el,
+      'Session ID': new Date().getTime() + '.' + Math.random().toString(36).substring(5),
+      'Hit TimeStamp': new Date().toUTCString()
+    };
   }

--- a/app/assets/javascripts/getAvailability.js
+++ b/app/assets/javascripts/getAvailability.js
@@ -15,8 +15,7 @@ export function getAvailability(nuanceAvailabilityMessage) {
     }
   }
 
-export const availabilityMessages = Object.freeze(
-    {
+export const availabilityMessages = Object.freeze({
       Ready: "Advisers are available to chat.", 
       Busy: "All of our advisers are busy at the moment. Keep checking this page until the 'speak to an adviser' link becomes available.",
       InProgress: "You are in a webchat.",
@@ -25,8 +24,7 @@ export const availabilityMessages = Object.freeze(
   })
 
 
-export const availabilities = Object.freeze(
-    {
+export const availabilities = Object.freeze({
       Ready: "Ready", 
       Busy: "Busy",
       InProgress: "In Progress",

--- a/app/assets/javascripts/getAvailability.js
+++ b/app/assets/javascripts/getAvailability.js
@@ -1,19 +1,36 @@
-export function getAvailability(nuanceText) {
-    var availability;
-
-    if (nuanceText === "Advisers are available to chat.") {
-      availability = 'Ready';
-    } else if (nuanceText === "All of our advisers are busy at the moment. Keep checking this page until the 'speak to an adviser' link becomes available.") {
-      availability = 'Busy';
-    } else if (nuanceText === "You are in a webchat.") {
-      availability = 'In Progress';
-    } else if (nuanceText === "Our webchat is now closed.") {
-      availability = 'Offline';
-    } else if (nuanceText === "You are in a webchat. If you cannot access it, you may have another chat window open.") {
-      availability = 'In Chat';
-    } else {
-      availability = 'Not Responding';
+export function getAvailability(nuanceAvailabilityMessage) {
+    switch(nuanceAvailabilityMessage){
+      case availabilityMessages.Ready:
+        return availabilities.Ready;
+      case availabilityMessages.Busy:
+        return availabilities.Busy;
+      case availabilityMessages.InProgress:
+        return availabilities.InProgress;
+      case availabilityMessages.Offline:
+        return availabilities.Offline;
+      case availabilityMessages.InChat:
+        return availabilities.InChat;
+      default:
+        return availabilities.NotResponding; 
     }
-
-    return availability;
   }
+
+export const availabilityMessages = Object.freeze(
+    {
+      Ready: "Advisers are available to chat.", 
+      Busy: "All of our advisers are busy at the moment. Keep checking this page until the 'speak to an adviser' link becomes available.",
+      InProgress: "You are in a webchat.",
+      Offline: "Our webchat is now closed.",
+      InChat: "You are in a webchat. If you cannot access it, you may have another chat window open."
+  })
+
+
+export const availabilities = Object.freeze(
+    {
+      Ready: "Ready", 
+      Busy: "Busy",
+      InProgress: "In Progress",
+      Offline: "Offline",
+      InChat: "In Chat",
+      NotResponding: "Not Responding"
+  })

--- a/app/assets/javascripts/getAvailability.js
+++ b/app/assets/javascripts/getAvailability.js
@@ -30,5 +30,6 @@ export const availabilities = Object.freeze({
       InProgress: "In Progress",
       Offline: "Offline",
       InChat: "In Chat",
-      NotResponding: "Not Responding"
+      NotResponding: "Not Responding",
+      NuanceUnavailable: "Nuance Unavailable"
   })

--- a/app/assets/javascripts/gtm_dl.js
+++ b/app/assets/javascripts/gtm_dl.js
@@ -1,16 +1,3 @@
-import * as elementWatcher from './waitForEl'
-import * as statusObserver from './statusObserver'
-import * as dataLayerUpdater from './updateDatalayer'
+import * as nuanceWatcher from './waitForChanges'
 
-
-function gtmDl(d, w, el) {
-  $(window).on("load", function () {
-    elementWatcher.waitForEl(el + ' div span', function () {
-      dataLayerUpdater.updateDataLayer(el,w,d);
-
-      statusObserver.observeStatus(el,w,d);
-    });
-  });
-};
-
-gtmDl(document, window, '#HMRC_Fixed_1');
+nuanceWatcher.waitForChanges(document, window);

--- a/app/assets/javascripts/waitForChanges.js
+++ b/app/assets/javascripts/waitForChanges.js
@@ -1,0 +1,41 @@
+import * as elementWatcher from './waitForEl'
+import * as statusObserver from './statusObserver'
+import * as dataLayerUpdater from './updateDatalayer'
+
+
+export function waitForChanges(d, w) {
+  $(window).on("load", function () {
+    if (window.location.pathname.includes("payment-problems")) {
+      elementWatcher.waitForEl('#pp_self_assessment_webchat' + ' div span', function () {
+        dataLayerUpdater.updateDataLayer('#pp_self_assessment_webchat',w,d);
+  
+        statusObserver.observeStatus('#pp_self_assessment_webchat',w,d);
+      });
+
+      elementWatcher.waitForEl('#pp_vat_webchat' + ' div span', function () {
+        dataLayerUpdater.updateDataLayer('#pp_vat_webchat',w,d);
+  
+        statusObserver.observeStatus('#pp_vat_webchat',w,d);
+      });
+
+      elementWatcher.waitForEl('#pp_paye_webchat' + ' div span', function () {
+        dataLayerUpdater.updateDataLayer('#pp_paye_webchat',w,d);
+  
+        statusObserver.observeStatus('#pp_paye_webchat',w,d);
+      });
+
+      elementWatcher.waitForEl('#pp_corporation_tax_webchat' + ' div span', function () {
+        dataLayerUpdater.updateDataLayer('#pp_corporation_tax_webchat',w,d);
+  
+        statusObserver.observeStatus('#pp_corporation_tax_webchat',w,d);
+      });
+
+    } else {
+      elementWatcher.waitForEl('#HMRC_Fixed_1' + ' div span', function () {
+        dataLayerUpdater.updateDataLayer('#HMRC_Fixed_1',w,d);
+  
+        statusObserver.observeStatus('#HMRC_Fixed_1',w,d);
+      });
+    }
+  });
+};

--- a/app/assets/javascripts/waitForChanges.js
+++ b/app/assets/javascripts/waitForChanges.js
@@ -21,5 +21,5 @@ function waitForNuanceElement(el,w,d) {
     dataLayerUpdater.updateDataLayer(el,w,d);
 
     statusObserver.observeStatus(el,w,d);
-  });
+  },w);
 }

--- a/app/assets/javascripts/waitForChanges.js
+++ b/app/assets/javascripts/waitForChanges.js
@@ -6,36 +6,20 @@ import * as dataLayerUpdater from './updateDatalayer'
 export function waitForChanges(d, w) {
   $(window).on("load", function () {
     if (window.location.pathname.includes("payment-problems")) {
-      elementWatcher.waitForEl('#pp_self_assessment_webchat', function () {
-        dataLayerUpdater.updateDataLayer('#pp_self_assessment_webchat',w,d);
-  
-        statusObserver.observeStatus('#pp_self_assessment_webchat',w,d);
-      });
-
-      elementWatcher.waitForEl('#pp_vat_webchat', function () {
-        dataLayerUpdater.updateDataLayer('#pp_vat_webchat',w,d);
-  
-        statusObserver.observeStatus('#pp_vat_webchat',w,d);
-      });
-
-      elementWatcher.waitForEl('#pp_paye_webchat', function () {
-        dataLayerUpdater.updateDataLayer('#pp_paye_webchat',w,d);
-  
-        statusObserver.observeStatus('#pp_paye_webchat',w,d);
-      });
-
-      elementWatcher.waitForEl('#pp_corporation_tax_webchat', function () {
-        dataLayerUpdater.updateDataLayer('#pp_corporation_tax_webchat',w,d);
-  
-        statusObserver.observeStatus('#pp_corporation_tax_webchat',w,d);
-      });
-
+      waitForNuanceElement('#pp_self_assessment_webchat',w,d);
+      waitForNuanceElement('#pp_vat_webchat',w,d);
+      waitForNuanceElement('#pp_paye_webchat',w,d);
+      waitForNuanceElement('#pp_corporation_tax_webchat',w,d);
     } else {
-      elementWatcher.waitForEl('#HMRC_Fixed_1', function () {
-        dataLayerUpdater.updateDataLayer('#HMRC_Fixed_1',w,d);
-  
-        statusObserver.observeStatus('#HMRC_Fixed_1',w,d);
-      });
+      waitForNuanceElement('#HMRC_Fixed_1',w,d);
     }
   });
 };
+
+function waitForNuanceElement(el,w,d) {
+  elementWatcher.waitForEl(el, function () {
+    dataLayerUpdater.updateDataLayer(el,w,d);
+
+    statusObserver.observeStatus(el,w,d);
+  });
+}

--- a/app/assets/javascripts/waitForChanges.js
+++ b/app/assets/javascripts/waitForChanges.js
@@ -6,32 +6,32 @@ import * as dataLayerUpdater from './updateDatalayer'
 export function waitForChanges(d, w) {
   $(window).on("load", function () {
     if (window.location.pathname.includes("payment-problems")) {
-      elementWatcher.waitForEl('#pp_self_assessment_webchat' + ' div span', function () {
+      elementWatcher.waitForEl('#pp_self_assessment_webchat', function () {
         dataLayerUpdater.updateDataLayer('#pp_self_assessment_webchat',w,d);
   
         statusObserver.observeStatus('#pp_self_assessment_webchat',w,d);
       });
 
-      elementWatcher.waitForEl('#pp_vat_webchat' + ' div span', function () {
+      elementWatcher.waitForEl('#pp_vat_webchat', function () {
         dataLayerUpdater.updateDataLayer('#pp_vat_webchat',w,d);
   
         statusObserver.observeStatus('#pp_vat_webchat',w,d);
       });
 
-      elementWatcher.waitForEl('#pp_paye_webchat' + ' div span', function () {
+      elementWatcher.waitForEl('#pp_paye_webchat', function () {
         dataLayerUpdater.updateDataLayer('#pp_paye_webchat',w,d);
   
         statusObserver.observeStatus('#pp_paye_webchat',w,d);
       });
 
-      elementWatcher.waitForEl('#pp_corporation_tax_webchat' + ' div span', function () {
+      elementWatcher.waitForEl('#pp_corporation_tax_webchat', function () {
         dataLayerUpdater.updateDataLayer('#pp_corporation_tax_webchat',w,d);
   
         statusObserver.observeStatus('#pp_corporation_tax_webchat',w,d);
       });
 
     } else {
-      elementWatcher.waitForEl('#HMRC_Fixed_1' + ' div span', function () {
+      elementWatcher.waitForEl('#HMRC_Fixed_1', function () {
         dataLayerUpdater.updateDataLayer('#HMRC_Fixed_1',w,d);
   
         statusObserver.observeStatus('#HMRC_Fixed_1',w,d);

--- a/app/assets/javascripts/waitForEl.js
+++ b/app/assets/javascripts/waitForEl.js
@@ -5,10 +5,11 @@ export function waitForEl (element, callback, defaultTimeout = 1000, timesChecke
     } else {
       setTimeout(function () {
         if (timesCheckedForElement>=9) {
+          defaultTimeout = 5000;
           $(element).text("Webchat is unavailable due to technical issues.")
         }
 
-        waitForEl(element, callback, timesCheckedForElement >= 9 ? 5000 : 1000, timesCheckedForElement + 1);
+        waitForEl(element, callback, defaultTimeout, timesCheckedForElement + 1);
       }, defaultTimeout);
     }
   }

--- a/app/assets/javascripts/waitForEl.js
+++ b/app/assets/javascripts/waitForEl.js
@@ -3,8 +3,8 @@ export function waitForEl (selector, callback, defaultTimeout = 1000, timesCheck
       callback();
     } else {
       setTimeout(function () {
-
         if (timesCheckedForElement>=9) {
+          console.log("waiting for " + selector)
           $("#HMRC_Fixed_1").text("Webchat is unavailable due to technical issues.")
         }
 

--- a/app/assets/javascripts/waitForEl.js
+++ b/app/assets/javascripts/waitForEl.js
@@ -1,14 +1,14 @@
-export function waitForEl (selector, callback, defaultTimeout = 1000, timesCheckedForElement = 1) {
+export function waitForEl (element, callback, defaultTimeout = 1000, timesCheckedForElement = 1) {
+    const selector = element + ' div span';
     if (jQuery(selector).length) {
       callback();
     } else {
       setTimeout(function () {
         if (timesCheckedForElement>=9) {
-          console.log("waiting for " + selector)
-          $("#HMRC_Fixed_1").text("Webchat is unavailable due to technical issues.")
+          $(element).text("Webchat is unavailable due to technical issues.")
         }
 
-        waitForEl(selector, callback, timesCheckedForElement >= 9 ? 5000 : 1000, timesCheckedForElement + 1);
+        waitForEl(element, callback, timesCheckedForElement >= 9 ? 5000 : 1000, timesCheckedForElement + 1);
       }, defaultTimeout);
     }
   }

--- a/app/assets/javascripts/waitForEl.js
+++ b/app/assets/javascripts/waitForEl.js
@@ -1,5 +1,5 @@
 import {availabilities} from './getAvailability'
-import {createDataLayerElement,saveToDataLayer} from './addToDataLayer'
+import {createDataLayerElement,reportEvent} from './addToDataLayer'
 
 export function waitForEl (element, callback, w, defaultTimeout = 1000, timesCheckedForElement = 1) {
     const selector = element + ' div span';
@@ -12,7 +12,7 @@ export function waitForEl (element, callback, w, defaultTimeout = 1000, timesChe
         if (timesCheckedForElement == maxNumberOfAttempts) {
           defaultTimeout = 5000;
           $(element).text("Webchat is unavailable due to technical issues.")
-          saveToDataLayer(w,createDataLayerElement(availabilities.NuanceUnavailable, element))
+          reportEvent(w,createDataLayerElement(availabilities.NuanceUnavailable, element))
         }
 
         waitForEl(element, callback, w, defaultTimeout, timesCheckedForElement + 1);

--- a/app/assets/javascripts/waitForEl.js
+++ b/app/assets/javascripts/waitForEl.js
@@ -1,7 +1,7 @@
 import {availabilities} from './getAvailability'
 import {createDataLayerElement,reportEvent} from './addToDataLayer'
 
-export function waitForEl (element, callback, w, defaultTimeout = 1000, timesCheckedForElement = 1) {
+export function waitForEl (element, callback, w, defaultTimeout = 1000, timesCheckedForElement = 0) {
     const selector = element + ' div span';
     const maxNumberOfAttempts = 9;
 
@@ -10,9 +10,9 @@ export function waitForEl (element, callback, w, defaultTimeout = 1000, timesChe
     } else {
       setTimeout(function () {
         if (timesCheckedForElement == maxNumberOfAttempts) {
-          defaultTimeout = 5000;
           $(element).text("Webchat is unavailable due to technical issues.")
           reportEvent(w,createDataLayerElement(availabilities.NuanceUnavailable, element))
+          return;
         }
 
         waitForEl(element, callback, w, defaultTimeout, timesCheckedForElement + 1);

--- a/app/assets/javascripts/waitForEl.js
+++ b/app/assets/javascripts/waitForEl.js
@@ -3,6 +3,11 @@ export function waitForEl (selector, callback, defaultTimeout = 1000, timesCheck
       callback();
     } else {
       setTimeout(function () {
+
+        if (timesCheckedForElement>=9) {
+          $("#HMRC_Fixed_1").text("Webchat is unavailable due to technical issues.")
+        }
+
         waitForEl(selector, callback, timesCheckedForElement >= 9 ? 5000 : 1000, timesCheckedForElement + 1);
       }, defaultTimeout);
     }

--- a/app/assets/javascripts/waitForEl.js
+++ b/app/assets/javascripts/waitForEl.js
@@ -1,10 +1,12 @@
 export function waitForEl (element, callback, defaultTimeout = 1000, timesCheckedForElement = 1) {
     const selector = element + ' div span';
+    const maxNumberOfAttempts = 9;
+    
     if (jQuery(selector).length) {
       callback();
     } else {
       setTimeout(function () {
-        if (timesCheckedForElement>=9) {
+        if (timesCheckedForElement == maxNumberOfAttempts) {
           defaultTimeout = 5000;
           $(element).text("Webchat is unavailable due to technical issues.")
         }

--- a/app/assets/javascripts/waitForEl.js
+++ b/app/assets/javascripts/waitForEl.js
@@ -1,7 +1,10 @@
-export function waitForEl (element, callback, defaultTimeout = 1000, timesCheckedForElement = 1) {
+import {availabilities} from './getAvailability'
+import {createDataLayerElement} from './addToDataLayer'
+
+export function waitForEl (element, callback, w, defaultTimeout = 1000, timesCheckedForElement = 1) {
     const selector = element + ' div span';
     const maxNumberOfAttempts = 9;
-    
+
     if (jQuery(selector).length) {
       callback();
     } else {
@@ -9,9 +12,12 @@ export function waitForEl (element, callback, defaultTimeout = 1000, timesChecke
         if (timesCheckedForElement == maxNumberOfAttempts) {
           defaultTimeout = 5000;
           $(element).text("Webchat is unavailable due to technical issues.")
+          w.dataLayer = w.dataLayer || [];
+
+          w.dataLayer.push(createDataLayerElement(availabilities.NuanceUnavailable, element));
         }
 
-        waitForEl(element, callback, defaultTimeout, timesCheckedForElement + 1);
+        waitForEl(element, callback, w, defaultTimeout, timesCheckedForElement + 1);
       }, defaultTimeout);
     }
   }

--- a/app/assets/javascripts/waitForEl.js
+++ b/app/assets/javascripts/waitForEl.js
@@ -1,5 +1,5 @@
 import {availabilities} from './getAvailability'
-import {createDataLayerElement} from './addToDataLayer'
+import {createDataLayerElement,saveToDataLayer} from './addToDataLayer'
 
 export function waitForEl (element, callback, w, defaultTimeout = 1000, timesCheckedForElement = 1) {
     const selector = element + ' div span';
@@ -12,9 +12,7 @@ export function waitForEl (element, callback, w, defaultTimeout = 1000, timesChe
         if (timesCheckedForElement == maxNumberOfAttempts) {
           defaultTimeout = 5000;
           $(element).text("Webchat is unavailable due to technical issues.")
-          w.dataLayer = w.dataLayer || [];
-
-          w.dataLayer.push(createDataLayerElement(availabilities.NuanceUnavailable, element));
+          saveToDataLayer(w,createDataLayerElement(availabilities.NuanceUnavailable, element))
         }
 
         waitForEl(element, callback, w, defaultTimeout, timesCheckedForElement + 1);

--- a/app/assets/javascripts/waitForEl.js
+++ b/app/assets/javascripts/waitForEl.js
@@ -1,9 +1,9 @@
-export function waitForEl (selector, callback, defaultTimeout = 1000) {
+export function waitForEl (selector, callback, defaultTimeout = 1000, timesCheckedForElement = 1) {
     if (jQuery(selector).length) {
       callback();
     } else {
       setTimeout(function () {
-        waitForEl(selector, callback);
+        waitForEl(selector, callback, timesCheckedForElement >= 9 ? 5000 : 1000, timesCheckedForElement + 1);
       }, defaultTimeout);
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
       "./test/javascripts/setup.js"
     ],
     "testRegex": "((\\.|/*.)(spec))\\.js?$",
-    "verbose" : true
+    "verbose": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
   "jest": {
     "setupFiles": [
       "./test/javascripts/setup.js"
-    ]
+    ],
+    "testRegex": "((\\.|/*.)(spec))\\.js?$",
+    "verbose" : true
   }
 }

--- a/test/javascripts/addToDataLayer.spec.js
+++ b/test/javascripts/addToDataLayer.spec.js
@@ -35,3 +35,21 @@ describe("Add to data layer", function() {
         expect(w.dataLayer[0].engine).toBe('v6');
 	});
 });
+
+describe("Save to data layer", function() {
+    it("will save an element", () => {
+        var w = {dataLayer : []};
+
+        SUT.saveToDataLayer(w,{test:"test"})
+
+        expect(w.dataLayer[0].test).toEqual("test");
+    });
+
+    it("will initialise data layer if there is no dataLayer array", () => {
+        var w = {dataLayer : undefined};
+
+        SUT.saveToDataLayer(w,{test:"test"})
+
+        expect(w.dataLayer[0].test).toEqual("test");
+    });
+});

--- a/test/javascripts/addToDataLayer.spec.js
+++ b/test/javascripts/addToDataLayer.spec.js
@@ -40,7 +40,7 @@ describe("Save to data layer", function() {
     it("will save an element", () => {
         var w = {dataLayer : []};
 
-        SUT.saveToDataLayer(w,{test:"test"})
+        SUT.reportEvent(w,{test:"test"})
 
         expect(w.dataLayer[0].test).toEqual("test");
     });
@@ -48,7 +48,7 @@ describe("Save to data layer", function() {
     it("will initialise data layer if there is no dataLayer array", () => {
         var w = {dataLayer : undefined};
 
-        SUT.saveToDataLayer(w,{test:"test"})
+        SUT.reportEvent(w,{test:"test"})
 
         expect(w.dataLayer[0].test).toEqual("test");
     });

--- a/test/javascripts/getAvailability.spec.js
+++ b/test/javascripts/getAvailability.spec.js
@@ -3,38 +3,38 @@
 
 describe("Set availability", function() {
   	it("will be `Ready` when nuance reports `Advisers are available to chat.`", () => {
-		const availability = SUT.getAvailability("Advisers are available to chat.");
+		const availability = SUT.getAvailability(SUT.availabilityMessages.Ready);
 
-		expect(availability).toBe("Ready");
+		expect(availability).toBe(SUT.availabilities.Ready);
 	});
 
 	it("will be `Busy` when nuance reports `All of our advisers are busy at the moment. Keep checking this page until the 'speak to an adviser' link becomes available.`", () => {
-		const availability = SUT.getAvailability("All of our advisers are busy at the moment. Keep checking this page until the 'speak to an adviser' link becomes available.");
+		const availability = SUT.getAvailability(SUT.availabilityMessages.Busy);
 
-		expect(availability).toBe("Busy");
+		expect(availability).toBe(SUT.availabilities.Busy);
 	});
 
 	it("will be `In Progress` when nuance reports `You are in a webchat.`", () => {
-		const availability = SUT.getAvailability("You are in a webchat.");
+		const availability = SUT.getAvailability(SUT.availabilityMessages.InProgress);
 
-		expect(availability).toBe("In Progress");
+		expect(availability).toBe(SUT.availabilities.InProgress);
 	});
 
 	it("will be `Offline` when nuance reports `Our webchat is now closed.`", () => {
-		const availability = SUT.getAvailability("Our webchat is now closed.");
+		const availability = SUT.getAvailability(SUT.availabilityMessages.Offline);
 
-		expect(availability).toBe("Offline");
+		expect(availability).toBe(SUT.availabilities.Offline);
 	});
 
 	it("will be `In Chat` when nuance reports `You are in a webchat. If you cannot access it, you may have another chat window open.`", () => {
-		const availability = SUT.getAvailability("You are in a webchat. If you cannot access it, you may have another chat window open.");
+		const availability = SUT.getAvailability(SUT.availabilityMessages.InChat);
 
-		expect(availability).toBe("In Chat");
+		expect(availability).toBe(SUT.availabilities.InChat);
 	});
 
 	it("will be `Not Responding` for any unknown report from nuance", () => {
 		const availability = SUT.getAvailability("test");
 
-		expect(availability).toBe("Not Responding")
+		expect(availability).toBe(SUT.availabilities.NotResponding)
 	});
 });

--- a/test/javascripts/statusObserver.spec.js
+++ b/test/javascripts/statusObserver.spec.js
@@ -1,5 +1,4 @@
 import * as SUT from '../../app/assets/javascripts/statusObserver'
-import * as dataLayerUpdater from '../../app/assets/javascripts/updateDatalayer'
 
 describe("The status observer", function() {
     var isObserved = false;

--- a/test/javascripts/waitForChanges.spec.js
+++ b/test/javascripts/waitForChanges.spec.js
@@ -1,0 +1,107 @@
+import * as SUT from '../../app/assets/javascripts/waitForChanges'
+import * as elementWatcher from '../../app/assets/javascripts/waitForEl'
+
+
+describe("When loading a page and waiting for changes", () => {
+    let elementWatcherMock;
+
+    beforeEach(() => {
+        delete window.location;
+
+        elementWatcherMock = jest.spyOn(
+            elementWatcher,
+            'waitForEl'
+        ).mockImplementation(jest.fn());
+    });
+
+    afterEach(() => {
+        elementWatcherMock.mockRestore();
+    });
+
+    describe("If the page is not `/payment-problems`", () => {
+        it("will consume element #HMRC_Fixed_1", () => {
+            window.location = {
+                pathname: '/ask-hmrc/webchat/test'
+            };
+
+            document.body.innerHTML = `<input type="text" id="test">`
+    
+            SUT.waitForChanges(document,window);
+            $(window).trigger('load');
+
+            expect(elementWatcherMock).toHaveBeenCalled();
+            expect(elementWatcherMock.mock.calls[0][0]).toEqual("#HMRC_Fixed_1 div span")
+        });
+    });
+
+    describe("If the page is `/payment-problems`", () => {
+        it("will not consume element #HMRC_Fixed_1", () => {
+            window.location = {
+                pathname: '/ask-hmrc/webchat/payment-problems'
+            };
+
+            document.body.innerHTML = `<input type="text" id="test">`
+    
+            SUT.waitForChanges(document,window);
+            $(window).trigger('load');
+
+            expect(elementWatcherMock.mock.calls[0][0]).not.toEqual("#HMRC_Fixed_1 div span")
+        });
+
+        it("will consume element #pp_self_assessment_webchat", () => {
+            window.location = {
+                pathname: '/ask-hmrc/webchat/payment-problems'
+            };
+
+            document.body.innerHTML = `<input type="text" id="test">`
+    
+            SUT.waitForChanges(document,window);
+            $(window).trigger('load');
+
+            expect(elementWatcherMock).toHaveBeenCalled();
+            expect(elementWatcherMock.mock.calls[0][0]).toEqual("#pp_self_assessment_webchat div span")
+        });
+
+        it("will consume element #pp_vat_webchat", () => {
+            window.location = {
+                pathname: '/ask-hmrc/webchat/payment-problems'
+            };
+
+            document.body.innerHTML = `<input type="text" id="test">`
+    
+            SUT.waitForChanges(document,window);
+            $(window).trigger('load');
+
+            expect(elementWatcherMock).toHaveBeenCalled();
+            expect(elementWatcherMock.mock.calls[1][0]).toEqual("#pp_vat_webchat div span")
+        });
+
+        it("will consume element #pp_paye_webchat", () => {
+            window.location = {
+                pathname: '/ask-hmrc/webchat/payment-problems'
+            };
+
+            document.body.innerHTML = `<input type="text" id="test">`
+    
+            SUT.waitForChanges(document,window);
+            $(window).trigger('load');
+
+            expect(elementWatcherMock).toHaveBeenCalled();
+            expect(elementWatcherMock.mock.calls[2][0]).toEqual("#pp_paye_webchat div span")
+        });
+
+        it("will consume element #pp_corporation_tax_webchat", () => {
+            window.location = {
+                pathname: '/ask-hmrc/webchat/payment-problems'
+            };
+
+            document.body.innerHTML = `<input type="text" id="test">`
+    
+            SUT.waitForChanges(document,window);
+            $(window).trigger('load');
+
+            expect(elementWatcherMock).toHaveBeenCalled();
+            expect(elementWatcherMock.mock.calls[3][0]).toEqual("#pp_corporation_tax_webchat div span")
+        });
+    });
+});

--- a/test/javascripts/waitForChanges.spec.js
+++ b/test/javascripts/waitForChanges.spec.js
@@ -30,7 +30,7 @@ describe("When loading a page and waiting for changes", () => {
             $(window).trigger('load');
 
             expect(elementWatcherMock).toHaveBeenCalled();
-            expect(elementWatcherMock.mock.calls[0][0]).toEqual("#HMRC_Fixed_1 div span")
+            expect(elementWatcherMock.mock.calls[0][0]).toEqual("#HMRC_Fixed_1")
         });
     });
 
@@ -45,7 +45,7 @@ describe("When loading a page and waiting for changes", () => {
             SUT.waitForChanges(document,window);
             $(window).trigger('load');
 
-            expect(elementWatcherMock.mock.calls[0][0]).not.toEqual("#HMRC_Fixed_1 div span")
+            expect(elementWatcherMock.mock.calls[0][0]).not.toEqual("#HMRC_Fixed_1")
         });
 
         it("will consume element #pp_self_assessment_webchat", () => {
@@ -59,7 +59,7 @@ describe("When loading a page and waiting for changes", () => {
             $(window).trigger('load');
 
             expect(elementWatcherMock).toHaveBeenCalled();
-            expect(elementWatcherMock.mock.calls[0][0]).toEqual("#pp_self_assessment_webchat div span")
+            expect(elementWatcherMock.mock.calls[0][0]).toEqual("#pp_self_assessment_webchat")
         });
 
         it("will consume element #pp_vat_webchat", () => {
@@ -73,7 +73,7 @@ describe("When loading a page and waiting for changes", () => {
             $(window).trigger('load');
 
             expect(elementWatcherMock).toHaveBeenCalled();
-            expect(elementWatcherMock.mock.calls[1][0]).toEqual("#pp_vat_webchat div span")
+            expect(elementWatcherMock.mock.calls[1][0]).toEqual("#pp_vat_webchat")
         });
 
         it("will consume element #pp_paye_webchat", () => {
@@ -87,7 +87,7 @@ describe("When loading a page and waiting for changes", () => {
             $(window).trigger('load');
 
             expect(elementWatcherMock).toHaveBeenCalled();
-            expect(elementWatcherMock.mock.calls[2][0]).toEqual("#pp_paye_webchat div span")
+            expect(elementWatcherMock.mock.calls[2][0]).toEqual("#pp_paye_webchat")
         });
 
         it("will consume element #pp_corporation_tax_webchat", () => {
@@ -101,7 +101,7 @@ describe("When loading a page and waiting for changes", () => {
             $(window).trigger('load');
 
             expect(elementWatcherMock).toHaveBeenCalled();
-            expect(elementWatcherMock.mock.calls[3][0]).toEqual("#pp_corporation_tax_webchat div span")
+            expect(elementWatcherMock.mock.calls[3][0]).toEqual("#pp_corporation_tax_webchat")
         });
     });
 });

--- a/test/javascripts/waitForEl.spec.js
+++ b/test/javascripts/waitForEl.spec.js
@@ -41,15 +41,17 @@ describe("When waiting for an element", () => {
 			expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
 		});
 
-		it("after 10 attempts looking for the element, it will start looking every 5000 ms", () => {
-			document.body.innerHTML = `<input type="text" id="test2">`
-	
-			SUT.waitForEl("#test",() => true);
-	
-			checkForElement9Times();
-	
-			expect(setTimeout).toHaveBeenCalledTimes(10);
-			expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 5000);
+		describe("And we have already checked 10 times", () => {
+			it("it will start looking for the element every 5000 ms", () => {
+				document.body.innerHTML = `<input type="text" id="test2">`
+		
+				SUT.waitForEl("#test",() => true);
+		
+				checkForElement9Times();
+		
+				expect(setTimeout).toHaveBeenCalledTimes(10);
+				expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 5000);
+			});
 		});
 	});
 });

--- a/test/javascripts/waitForEl.spec.js
+++ b/test/javascripts/waitForEl.spec.js
@@ -2,9 +2,9 @@ import * as SUT from '../../app/assets/javascripts/waitForEl'
 import {availabilities} from '../../app/assets/javascripts/getAvailability'
 
 describe("When waiting for an element", () => {
-	let w;
+	let window;
 	beforeEach(() => {
-		w = {dataLayer : []};
+		window = {dataLayer : []};
 	    jest.useFakeTimers();
 	});
 
@@ -15,7 +15,7 @@ describe("When waiting for an element", () => {
 		var output;
 		document.body.innerHTML = `<div id="test"><div><span>Test</span></div></div>`
 
-		SUT.waitForEl("#test",() => {output = "success"}, w);
+		SUT.waitForEl("#test",() => {output = "success"}, window);
 
 		expect(output).toEqual("success");
 	});
@@ -25,7 +25,7 @@ describe("When waiting for an element", () => {
 		it("will attempt to fetch element again once wait is over", () => {
 			document.body.innerHTML = `<input type="text" id="test2">`
 	
-			SUT.waitForEl("#test",() => true, w);
+			SUT.waitForEl("#test",() => true, window);
 	
 			jest.runOnlyPendingTimers();
 	
@@ -37,7 +37,7 @@ describe("When waiting for an element", () => {
 	
 			document.body.innerHTML = `<input type="text" id="test2">`
 	
-			SUT.waitForEl("#test",() => {output = "success"}, w);
+			SUT.waitForEl("#test",() => {output = "success"}, window);
 	
 			expect(setTimeout).toHaveBeenCalledTimes(1);
 			expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
@@ -47,7 +47,7 @@ describe("When waiting for an element", () => {
 			it("will start looking for the element every 5 seconds", () => {
 				document.body.innerHTML = `<input type="text" id="test2">`
 		
-				SUT.waitForEl("#test",() => true, w);
+				SUT.waitForEl("#test",() => true, window);
 		
 				checkForElementTimes(9);
 		
@@ -58,7 +58,7 @@ describe("When waiting for an element", () => {
 			it("will report on technical difficulties", () => {
 				document.body.innerHTML = `<div id="HMRC_Fixed_1"></div>`
 		
-				SUT.waitForEl("#HMRC_Fixed_1",() => true, w);
+				SUT.waitForEl("#HMRC_Fixed_1",() => true, window);
 		
 				checkForElementTimes(9);
 		
@@ -68,28 +68,28 @@ describe("When waiting for an element", () => {
 			it("will raise a technical difficultes event on data layer", () => {
 				document.body.innerHTML = `<div id="HMRC_Fixed_1"></div>`
 		
-				SUT.waitForEl("#HMRC_Fixed_1",() => true, w);
+				SUT.waitForEl("#HMRC_Fixed_1",() => true, window);
 		
 				checkForElementTimes(9);
 		
-				expect(w.dataLayer[0].event).toBe('DOMContentLoaded');
-				expect(w.dataLayer[0].ID).toBe('#HMRC_Fixed_1');
-				expect(w.dataLayer[0].Status).toBe(availabilities.NuanceUnavailable);
-				expect(w.dataLayer[0]["Session ID"]).not.toBe(undefined);
-				expect(w.dataLayer[0]["Hit TimeStamp"]).not.toBe(undefined)			
+				expect(window.dataLayer[0].event).toBe('DOMContentLoaded');
+				expect(window.dataLayer[0].ID).toBe('#HMRC_Fixed_1');
+				expect(window.dataLayer[0].Status).toBe(availabilities.NuanceUnavailable);
+				expect(window.dataLayer[0]["Session ID"]).not.toBe(undefined);
+				expect(window.dataLayer[0]["Hit TimeStamp"]).not.toBe(undefined)			
 			});
 
 			it("will report on technical difficulties and to data layer only once", () => {
 				document.body.innerHTML = `<div id="HMRC_Fixed_1"></div>`
 		
-				SUT.waitForEl("#HMRC_Fixed_1",() => true, w);
+				SUT.waitForEl("#HMRC_Fixed_1",() => true, window);
 		
 				checkForElementTimes(9);
 				$("#HMRC_Fixed_1").text("Text not changed")
 				jest.runOnlyPendingTimers();
 		
 				expect($("#HMRC_Fixed_1").text()).toEqual("Text not changed")
-				expect(w.dataLayer.length).toEqual(1)
+				expect(window.dataLayer.length).toEqual(1)
 			});
 		});
 	});

--- a/test/javascripts/waitForEl.spec.js
+++ b/test/javascripts/waitForEl.spec.js
@@ -44,15 +44,15 @@ describe("When waiting for an element", () => {
 		});
 
 		describe("And we have already checked 10 times", () => {
-			it("will start looking for the element every 5 seconds", () => {
+			//DEP-248: Nuance will never recover from failure asyncrhronously, therefore there is no point on checking for Nuance after technical difficulties.
+			it("will cease looking for the element", () => {
 				document.body.innerHTML = `<input type="text" id="test2">`
 		
 				SUT.waitForEl("#test",() => true, window);
 		
-				checkForElementTimes(9);
+				checkForElementTimes(15);
 		
 				expect(setTimeout).toHaveBeenCalledTimes(10);
-				expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 5000);
 			});
 
 			it("will report on technical difficulties", () => {
@@ -60,7 +60,7 @@ describe("When waiting for an element", () => {
 		
 				SUT.waitForEl("#HMRC_Fixed_1",() => true, window);
 		
-				checkForElementTimes(9);
+				checkForElementTimes(10);
 		
 				expect($("#HMRC_Fixed_1").text()).toEqual("Webchat is unavailable due to technical issues.")
 			});
@@ -70,7 +70,7 @@ describe("When waiting for an element", () => {
 		
 				SUT.waitForEl("#HMRC_Fixed_1",() => true, window);
 		
-				checkForElementTimes(9);
+				checkForElementTimes(10);
 		
 				expect(window.dataLayer[0].event).toBe('DOMContentLoaded');
 				expect(window.dataLayer[0].ID).toBe('#HMRC_Fixed_1');
@@ -84,7 +84,7 @@ describe("When waiting for an element", () => {
 		
 				SUT.waitForEl("#HMRC_Fixed_1",() => true, window);
 		
-				checkForElementTimes(9);
+				checkForElementTimes(10);
 				$("#HMRC_Fixed_1").text("Text not changed")
 				jest.runOnlyPendingTimers();
 		

--- a/test/javascripts/waitForEl.spec.js
+++ b/test/javascripts/waitForEl.spec.js
@@ -1,6 +1,6 @@
 import * as SUT from '../../app/assets/javascripts/waitForEl'
 
-describe("When waiting for an element", function() {
+describe("When waiting for an element", () => {
 	
 	beforeEach(() => {
 	    jest.useFakeTimers();
@@ -18,26 +18,51 @@ describe("When waiting for an element", function() {
 		expect(output).toEqual("success");
 	});
 
-	it("will wait by default 1000ms before attempting to check the element again when it is not there", () => {
-		var output;
 
-		document.body.innerHTML = `<input type="text" id="test2">`
+	describe("If the element we are waiting for is not available", () => {
+		it("will attempt to fetch element again once wait is over", () => {
+			document.body.innerHTML = `<input type="text" id="test2">`
+	
+			SUT.waitForEl("#test",() => true);
+	
+			jest.runOnlyPendingTimers();
+	
+			expect(setTimeout).toHaveBeenCalledTimes(2);
+			expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+		});
+		it("will wait by default 1000ms before attempting to check the element again", () => {
+			var output;
+	
+			document.body.innerHTML = `<input type="text" id="test2">`
+	
+			SUT.waitForEl("#test",() => {output = "success"});
+	
+			expect(setTimeout).toHaveBeenCalledTimes(1);
+			expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+		});
 
-		SUT.waitForEl("#test",() => {output = "success"});
-
-		expect(setTimeout).toHaveBeenCalledTimes(1);
-		expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
-	});
-
-	it("will attempt to fetch element again once wait is over", () => {
-		document.body.innerHTML = `<input type="text" id="test2">`
-
-		SUT.waitForEl("#test",() => true);
-
-		jest.runOnlyPendingTimers();
-
-		expect(setTimeout).toHaveBeenCalledTimes(2);
-		expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+		it("after 10 attempts looking for the element, it will start looking every 5000 ms", () => {
+			document.body.innerHTML = `<input type="text" id="test2">`
+	
+			SUT.waitForEl("#test",() => true);
+	
+			checkForElement9Times();
+	
+			expect(setTimeout).toHaveBeenCalledTimes(10);
+			expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 5000);
+		});
 	});
 });
+
+function checkForElement9Times() {
+	jest.runOnlyPendingTimers();
+	jest.runOnlyPendingTimers();
+	jest.runOnlyPendingTimers();
+	jest.runOnlyPendingTimers();
+	jest.runOnlyPendingTimers();
+	jest.runOnlyPendingTimers();
+	jest.runOnlyPendingTimers();
+	jest.runOnlyPendingTimers();
+	jest.runOnlyPendingTimers();
+}
 

--- a/test/javascripts/waitForEl.spec.js
+++ b/test/javascripts/waitForEl.spec.js
@@ -62,6 +62,18 @@ describe("When waiting for an element", () => {
 		
 				expect($("#HMRC_Fixed_1").text()).toEqual("Webchat is unavailable due to technical issues.")
 			});
+
+			it("will report on technical difficulties only once", () => {
+				document.body.innerHTML = `<div id="HMRC_Fixed_1"></div>`
+		
+				SUT.waitForEl("#HMRC_Fixed_1",() => true);
+		
+				checkForElement9Times();
+				$("#HMRC_Fixed_1").text("Text not changed")
+				jest.runOnlyPendingTimers();
+		
+				expect($("#HMRC_Fixed_1").text()).toEqual("Text not changed")
+			});
 		});
 	});
 });

--- a/test/javascripts/waitForEl.spec.js
+++ b/test/javascripts/waitForEl.spec.js
@@ -49,7 +49,7 @@ describe("When waiting for an element", () => {
 		
 				SUT.waitForEl("#test",() => true, w);
 		
-				checkForElement9Times();
+				checkForElementTimes(9);
 		
 				expect(setTimeout).toHaveBeenCalledTimes(10);
 				expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 5000);
@@ -60,7 +60,7 @@ describe("When waiting for an element", () => {
 		
 				SUT.waitForEl("#HMRC_Fixed_1",() => true, w);
 		
-				checkForElement9Times();
+				checkForElementTimes(9);
 		
 				expect($("#HMRC_Fixed_1").text()).toEqual("Webchat is unavailable due to technical issues.")
 			});
@@ -70,7 +70,7 @@ describe("When waiting for an element", () => {
 		
 				SUT.waitForEl("#HMRC_Fixed_1",() => true, w);
 		
-				checkForElement9Times();
+				checkForElementTimes(9);
 		
 				expect(w.dataLayer[0].event).toBe('DOMContentLoaded');
 				expect(w.dataLayer[0].ID).toBe('#HMRC_Fixed_1');
@@ -84,7 +84,7 @@ describe("When waiting for an element", () => {
 		
 				SUT.waitForEl("#HMRC_Fixed_1",() => true, w);
 		
-				checkForElement9Times();
+				checkForElementTimes(9);
 				$("#HMRC_Fixed_1").text("Text not changed")
 				jest.runOnlyPendingTimers();
 		
@@ -95,15 +95,6 @@ describe("When waiting for an element", () => {
 	});
 });
 
-function checkForElement9Times() {
-	jest.runOnlyPendingTimers();
-	jest.runOnlyPendingTimers();
-	jest.runOnlyPendingTimers();
-	jest.runOnlyPendingTimers();
-	jest.runOnlyPendingTimers();
-	jest.runOnlyPendingTimers();
-	jest.runOnlyPendingTimers();
-	jest.runOnlyPendingTimers();
-	jest.runOnlyPendingTimers();
-}
+const checkForElementTimes = (numberOfTimes) => { for (var i = 0; i < numberOfTimes; i++) jest.runOnlyPendingTimers() };
+
 

--- a/test/javascripts/waitForEl.spec.js
+++ b/test/javascripts/waitForEl.spec.js
@@ -42,7 +42,7 @@ describe("When waiting for an element", () => {
 		});
 
 		describe("And we have already checked 10 times", () => {
-			it("it will start looking for the element every 5000 ms", () => {
+			it("will start looking for the element every 5000 ms", () => {
 				document.body.innerHTML = `<input type="text" id="test2">`
 		
 				SUT.waitForEl("#test",() => true);
@@ -51,6 +51,16 @@ describe("When waiting for an element", () => {
 		
 				expect(setTimeout).toHaveBeenCalledTimes(10);
 				expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 5000);
+			});
+
+			it("will report on technical difficulties", () => {
+				document.body.innerHTML = `<div id="HMRC_Fixed_1"></div>`
+		
+				SUT.waitForEl("#test",() => true);
+		
+				checkForElement9Times();
+		
+				expect($("#HMRC_Fixed_1").text()).toEqual("Webchat is unavailable due to technical issues.")
 			});
 		});
 	});

--- a/test/javascripts/waitForEl.spec.js
+++ b/test/javascripts/waitForEl.spec.js
@@ -30,7 +30,7 @@ describe("When waiting for an element", () => {
 			expect(setTimeout).toHaveBeenCalledTimes(2);
 			expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
 		});
-		it("will wait by default 1000ms before attempting to check the element again", () => {
+		it("will wait by default 1 second before attempting to check the element again", () => {
 			var output;
 	
 			document.body.innerHTML = `<input type="text" id="test2">`
@@ -42,7 +42,7 @@ describe("When waiting for an element", () => {
 		});
 
 		describe("And we have already checked 10 times", () => {
-			it("will start looking for the element every 5000 ms", () => {
+			it("will start looking for the element every 5 seconds", () => {
 				document.body.innerHTML = `<input type="text" id="test2">`
 		
 				SUT.waitForEl("#test",() => true);

--- a/test/javascripts/waitForEl.spec.js
+++ b/test/javascripts/waitForEl.spec.js
@@ -11,7 +11,7 @@ describe("When waiting for an element", () => {
 	});
 	it("will execute the callback if the element exists", () => {
 		var output;
-		document.body.innerHTML = `<input type="text" id="test">`
+		document.body.innerHTML = `<div id="test"><div><span>Test</span></div></div>`
 
 		SUT.waitForEl("#test",() => {output = "success"});
 
@@ -56,7 +56,7 @@ describe("When waiting for an element", () => {
 			it("will report on technical difficulties", () => {
 				document.body.innerHTML = `<div id="HMRC_Fixed_1"></div>`
 		
-				SUT.waitForEl("#test",() => true);
+				SUT.waitForEl("#HMRC_Fixed_1",() => true);
 		
 				checkForElement9Times();
 		

--- a/test/javascripts/waitForEl.spec.js
+++ b/test/javascripts/waitForEl.spec.js
@@ -1,8 +1,10 @@
 import * as SUT from '../../app/assets/javascripts/waitForEl'
+import {availabilities} from '../../app/assets/javascripts/getAvailability'
 
 describe("When waiting for an element", () => {
-	
+	let w;
 	beforeEach(() => {
+		w = {dataLayer : []};
 	    jest.useFakeTimers();
 	});
 
@@ -13,7 +15,7 @@ describe("When waiting for an element", () => {
 		var output;
 		document.body.innerHTML = `<div id="test"><div><span>Test</span></div></div>`
 
-		SUT.waitForEl("#test",() => {output = "success"});
+		SUT.waitForEl("#test",() => {output = "success"}, w);
 
 		expect(output).toEqual("success");
 	});
@@ -23,7 +25,7 @@ describe("When waiting for an element", () => {
 		it("will attempt to fetch element again once wait is over", () => {
 			document.body.innerHTML = `<input type="text" id="test2">`
 	
-			SUT.waitForEl("#test",() => true);
+			SUT.waitForEl("#test",() => true, w);
 	
 			jest.runOnlyPendingTimers();
 	
@@ -35,7 +37,7 @@ describe("When waiting for an element", () => {
 	
 			document.body.innerHTML = `<input type="text" id="test2">`
 	
-			SUT.waitForEl("#test",() => {output = "success"});
+			SUT.waitForEl("#test",() => {output = "success"}, w);
 	
 			expect(setTimeout).toHaveBeenCalledTimes(1);
 			expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
@@ -45,7 +47,7 @@ describe("When waiting for an element", () => {
 			it("will start looking for the element every 5 seconds", () => {
 				document.body.innerHTML = `<input type="text" id="test2">`
 		
-				SUT.waitForEl("#test",() => true);
+				SUT.waitForEl("#test",() => true, w);
 		
 				checkForElement9Times();
 		
@@ -56,23 +58,38 @@ describe("When waiting for an element", () => {
 			it("will report on technical difficulties", () => {
 				document.body.innerHTML = `<div id="HMRC_Fixed_1"></div>`
 		
-				SUT.waitForEl("#HMRC_Fixed_1",() => true);
+				SUT.waitForEl("#HMRC_Fixed_1",() => true, w);
 		
 				checkForElement9Times();
 		
 				expect($("#HMRC_Fixed_1").text()).toEqual("Webchat is unavailable due to technical issues.")
 			});
 
-			it("will report on technical difficulties only once", () => {
+			it("will raise a technical difficultes event on data layer", () => {
 				document.body.innerHTML = `<div id="HMRC_Fixed_1"></div>`
 		
-				SUT.waitForEl("#HMRC_Fixed_1",() => true);
+				SUT.waitForEl("#HMRC_Fixed_1",() => true, w);
+		
+				checkForElement9Times();
+		
+				expect(w.dataLayer[0].event).toBe('DOMContentLoaded');
+				expect(w.dataLayer[0].ID).toBe('#HMRC_Fixed_1');
+				expect(w.dataLayer[0].Status).toBe(availabilities.NuanceUnavailable);
+				expect(w.dataLayer[0]["Session ID"]).not.toBe(undefined);
+				expect(w.dataLayer[0]["Hit TimeStamp"]).not.toBe(undefined)			
+			});
+
+			it("will report on technical difficulties and to data layer only once", () => {
+				document.body.innerHTML = `<div id="HMRC_Fixed_1"></div>`
+		
+				SUT.waitForEl("#HMRC_Fixed_1",() => true, w);
 		
 				checkForElement9Times();
 				$("#HMRC_Fixed_1").text("Text not changed")
 				jest.runOnlyPendingTimers();
 		
 				expect($("#HMRC_Fixed_1").text()).toEqual("Text not changed")
+				expect(w.dataLayer.length).toEqual(1)
 			});
 		});
 	});


### PR DESCRIPTION
**Work performed**
1 - When waiting for Nuance Element, we wait 10 seconds (trying every second) to retrieve the agent availability. If after 10 seconds there is nothing from Nuance, then we will display "Technical Difficulties" message and we will start checking Nuance every 5 seconds, rather than every 1 second to lessen the load on the client.

2 - When showing "Technical Difficulties" we now send a GTM event too with "Nuance Unavailable"

**Other work perfromed**

1 - Hooked up `payment-problems` to GTM
2 - Refactoring of test suite and `gtm_dl.js` code.
3 - Abstract an ENUM for `Agent availability messages` and `Agent availability statuses`

**Testing considerations**

**_It is imperative we test this under a variety of conditions, including:_**
1 - `payment-problems` follows a different code path, so we need to test this page too.
2 - once `technical difficulties` is shown, we will `not` continue checking the container `div` for updates.