### PR TITLE
DEP-2525: Hide error div when chat container is shown

### DIFF
--- a/app/assets/javascripts/cuiChatListener.js
+++ b/app/assets/javascripts/cuiChatListener.js
@@ -109,8 +109,6 @@ export var chatListener = {
             loadingAnimation.hide();
         });
         $('.cui-technical-error').hide();
-
-
     },
     showLoadingAnimation: function() {
         var loadingAnimation = $(this.loadingAnimationSelector);

--- a/app/assets/javascripts/cuiChatListener.js
+++ b/app/assets/javascripts/cuiChatListener.js
@@ -108,6 +108,9 @@ export var chatListener = {
         loadingAnimation.fadeTo(1500, 0.0, function() {
             loadingAnimation.hide();
         });
+        $('.cui-technical-error').hide();
+
+
     },
     showLoadingAnimation: function() {
         var loadingAnimation = $(this.loadingAnimationSelector);


### PR DESCRIPTION
# DEP-2525: Hide error div when chat container is shown

## Checklist PR Raiser
 - [x]  I've ensured code coverage has not decreased
 - [x]  I've dealt with any new compilation warnings
 - [x]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [ ]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [ ]  I've checked to ensure all relevant unit tests have been written
 - [ ]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  If I merge I will ensure I use squash and merge