### PR TITLE
DEP-2525: Hiding error div when msg container div is present

### DIFF
--- a/app/assets/javascripts/cuiChatListener.js
+++ b/app/assets/javascripts/cuiChatListener.js
@@ -108,6 +108,9 @@ export var chatListener = {
         loadingAnimation.fadeTo(1500, 0.0, function() {
             loadingAnimation.hide();
         });
+        $('.cui-technical-error').hide();
+
+
     },
     showLoadingAnimation: function() {
         var loadingAnimation = $(this.loadingAnimationSelector);

--- a/app/assets/javascripts/cuiChatListener.js
+++ b/app/assets/javascripts/cuiChatListener.js
@@ -108,9 +108,9 @@ export var chatListener = {
         loadingAnimation.fadeTo(1500, 0.0, function() {
             loadingAnimation.hide();
         });
-        $('.cui-technical-error').hide();
-
-
+        if($("#ciapiSkinChatTranscript").length){
+             $('.cui-technical-error').hide();
+        }
     },
     showLoadingAnimation: function() {
         var loadingAnimation = $(this.loadingAnimationSelector);
@@ -121,10 +121,10 @@ export var chatListener = {
     },
     technicalError: function() {
         console.log("technicalError");
-        this.showNuanceDiv();
         var newDiv = $("<p>", {"class": "cui-technical-error error-message"})
         newDiv.text('There’s a problem with chat. Try again later.')
         $('#nuanMessagingFrame').append(newDiv);
+         this.showNuanceDiv();
     },
     waitForSignsOfLife: function() {
         var self = this;
@@ -133,6 +133,7 @@ export var chatListener = {
             console.log("Nuance is down...");
             self.technicalError();
         }, this.downTimeoutDuration);
+
     },
     loadFunction: null,
     startup: function(w) {


### PR DESCRIPTION
# DEP-2525: Hiding error div when msg container div is present

## Checklist PR Raiser
 - [ ]  I've ensured code coverage has not decreased
 - [ ]  I've dealt with any new compilation warnings
 - [ ]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [ ]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [x]  I've checked to ensure all relevant unit tests have been written
 - [x]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  If I merge I will ensure I use squash and merge