### PR TITLE
DEP-6200-Hiding-backlink

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -3,7 +3,20 @@ window.GOVUKFrontend.initAll();
 window.HMRCFrontend.initAll();
 
 window.addEventListener('DOMContentLoaded', function() {
-
+    // =====================================================
+    // Back link mimics browser back functionality
+    // =====================================================
+    var backLink = document.querySelector('.govuk-back-link');
+    if(window.history.length === 1 && window.history.back && typeof window.history.back === 'function') {
+        backLink.style.display = 'none';
+    }else{
+        backLink.style.display = 'block-inline'; 
+        backLink.addEventListener('click', function(e){
+            e.preventDefault();
+            window.history.back();
+        });
+    }
+    
     //Timer for notification banner
     //date format ( YYYY-MM-DD )
     //If BST then time needs to be 1 hour earlier
@@ -22,29 +35,6 @@ window.addEventListener('DOMContentLoaded', function() {
     } else {
         //Notification will not be displayed
         notificationBanner.style.display = 'none'
-    }
-
-    // =====================================================
-    // Back link mimics browser back functionality
-    // =====================================================
-
-    // back link
-    var backLink = document.querySelector('.govuk-back-link');
-    
-    window.onload = function() {
-        toggleBackLinkVisibility();
-    };
-
-    function toggleBackLinkVisibility() {
-        if(window.history.length === 1 && window.history.back && typeof window.history.back === 'function') {
-            backLink.style.display = 'none';
-        }else{
-            backLink.style.display = 'block-inline'; 
-            backLink.addEventListener('click', function(e){
-                e.preventDefault();
-                window.history.back();
-            });
-        }
     }
 });
 

--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -30,13 +30,21 @@ window.addEventListener('DOMContentLoaded', function() {
 
     // back link
     var backLink = document.querySelector('.govuk-back-link');
-    if(backLink){
-        backLink.addEventListener('click', function(e){
-            e.preventDefault();
-            if (window.history && window.history.back && typeof window.history.back === 'function'){
+    
+    window.onload = function() {
+        toggleBackLinkVisibility();
+    };
+
+    function toggleBackLinkVisibility() {
+        if(window.history.length === 1 && window.history.back && typeof window.history.back === 'function') {
+            backLink.style.display = 'none';
+        }else{
+            backLink.style.display = 'block-inline'; 
+            backLink.addEventListener('click', function(e){
+                e.preventDefault();
                 window.history.back();
-            }
-        });
+            });
+        }
     }
 });
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url(
   "HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.21.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 


### PR DESCRIPTION
# DEP-6200. Hides the backlink when there is no chat history. However, if window.history.length > 1, the backlink will show and there is no way of moving back. This was likely a small edge case and not going to impact the vast majority of user journey's.

## Checklist PR Raiser
 - [ ]  I've ensured code coverage has not decreased
 - [ ]  I've dealt with any new compilation warnings
 - [ ]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [ ]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [ ]  I've checked to ensure all relevant unit tests have been written
 - [ ]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  If I merge I will ensure I use squash and merge