### PR TITLE
Fixing DA list page, stopping showDAv4NCH feature toggle showing up 

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -71,7 +71,8 @@ class AppConfig @Inject()(config: Configuration) {
 
   def liveDigitalAssistants(messages: play.api.i18n.Messages) =
   config.underlying.getConfig("features.digitalAssistants").entrySet().asScala.collect {
-    case digitalAssistant if digitalAssistantIsLive(digitalAssistant.getKey) && !digitalAssistant.getKey.contains("showIVRWebchat") => digitalAssistant.getKey
+    case digitalAssistant if digitalAssistantIsLive(digitalAssistant.getKey)
+      && !digitalAssistant.getKey.contains("showIVRWebchat") && !digitalAssistant.getKey.contains("showDAv4") => digitalAssistant.getKey
   }.toList.sortBy(digitalAssistantKey => {
     val x = s"digital.assistant.list.$digitalAssistantKey.title"
     messages.apply(x)


### PR DESCRIPTION
Fixing issue on DA list page, stopping 'showDAv4NCH' feature toggle showing up with title/description on the page.

Adding **&& !digitalAssistant.getKey.contains("showDAv4")** to the if statement

## Checklist PR Raiser
 - [ ]  I've ensured code coverage has not decreased
 - [ ]  I've dealt with any new compilation warnings
 - [ ]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [ ]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [ ]  I've checked to ensure all relevant unit tests have been written
 - [ ]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  If I merge I will ensure I use squash and merge