### PR TITLE
Adding isCUI flag into the view for DAv4 NCH

### DIFF
--- a/app/views/webchat/dav4/DAv4NationalClearanceHubView.scala.html
+++ b/app/views/webchat/dav4/DAv4NationalClearanceHubView.scala.html
@@ -45,6 +45,8 @@
 }
 
 @scriptElem = {
+
+	<script @{CSPNonce.attr}> window.isCUI = true; </script>
 	<script @{CSPNonce.attr} src='@routes.Assets.versioned("javascripts/custom.js")'></script>
 	<script @{CSPNonce.attr} src='@routes.Assets.versioned("javascripts/bundle.js")'></script>
 


### PR DESCRIPTION
Adding window.isCUI=true into the view for DAv4 NCH. This DAv4 is our own chatskin, so CUI should be true. Also, the check 'waitForChanges' in 'gtm_dl.js' will not happen unnecessarily with this set to true 

## Checklist PR Raiser
 - [x]  I've ensured code coverage has not decreased
 - [x]  I've dealt with any new compilation warnings
 - [x]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [x]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [ ]  I've checked to ensure all relevant unit tests have been written
 - [ ]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  If I merge I will ensure I use squash and merge